### PR TITLE
Add support for kingpin commandline flags, access service token expiration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ This piece of software has one mission: gather Cloudflare Site analytics from th
 
 ### Considerations
 
-* **Tune your configuration**. All configuration is done through *environment variables*:
+* **Tune your configuration**. Can configuration is done through *environment variables* and optionally, command-line flags:
   * `CLOUDFLARE_EMAIL`: *(optional)* email used for Cloudflare API email authentication
   * `CLOUDFLARE_KEY`: *(optional)* key used for Cloudflare API email authentication
   * `CLOUDFLARE_TOKEN`: *(optional)* token used for Cloudflare API token authentication
   * `CLOUDFLARE_USER_SERVICE_KEY`: *(optional)* key used for Cloudflare API user service key authentication
-  * `CLOUDFLARE_ZONES`: *(required)* comma-separated list of zone names to scrape for metrics (e.g. `example.com,example.org`)
-  * `CLOUDFLARE_SCRAPE_ANALYTICS_SINCE`: *(default: `24h`)* `since` parameter of calls to the Cloudflare Analytics API
-  * `EXPORTER_LISTEN_ADDR`: *(default: `127.0.0.1:9199`)* address for the exporter to bind to
+  * `--cloudflare.zones`, `CLOUDFLARE_ZONES`: *(required)* comma-separated list of zone names to scrape for metrics (e.g. `example.com,example.org`)
+  * `--cloudflare.accounts`, `CLOUDFLARE_ACCOUNTS`: *(optional)* comma-separated list of account ids to scrape for metrics (e.g. `123548648,123548644868`)
+  * `--cloudflare.since`, `CLOUDFLARE_SCRAPE_ANALYTICS_SINCE`: *(default: `24h`)* `since` parameter of calls to the Cloudflare Analytics API
+  * `--cloudflare.include-access`: *(optional)* bool to enable Cloudflare Access-related metrics
+  * `--web.listen-addr`, `EXPORTER_LISTEN_ADDR`: *(default: `127.0.0.1:9199`)* address for the exporter to bind to
 * **Beware of rate limiting**, Cloudflare's API has a base limit of [1200 requests every 5 minutes](https://support.cloudflare.com/hc/en-us/articles/200171456-How-many-API-calls-can-I-make-). I recommend configuring your [Prometheis](https://prometheus.io/docs/introduction/faq/#what-is-the-plural-of-prometheus) to scrape `cloudflare_exporter` once every 1-5 minutes.
 
 ### With the prebuilt container image

--- a/exporter/Makefile
+++ b/exporter/Makefile
@@ -6,6 +6,7 @@ fmt:
 get:
 	GOPATH="$$PWD" go get github.com/prometheus/client_golang/prometheus
 	GOPATH="$$PWD" go get github.com/cloudflare/cloudflare-go
+	GOPATH="$$PWD" go get gopkg.in/alecthomas/kingpin.v2
 
 build:
 	GOPATH="$$PWD" CGO_ENABLED=0 go build .

--- a/exporter/configuration.go
+++ b/exporter/configuration.go
@@ -10,3 +10,14 @@ func EnvString(key string, fallback string) string {
 	}
 	return fallback
 }
+
+type ExporterConfig struct {
+	cloudflareEmail          string
+	cloudflareKey            string
+	cloudflareToken          string
+	cloudflareUserServiceKey string
+	cloudflareZones          string
+	cloudflareAccounts       string
+	cloudflareSince          string
+	cloudflareIncludeAccess  bool
+}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -1,28 +1,43 @@
 package main
 
 import (
+	"gopkg.in/alecthomas/kingpin.v2"
 	"log"
 )
 
 var (
-	CLOUDFLARE_EMAIL                  = EnvString("CLOUDFLARE_EMAIL", "")                     // (optional) email used for Cloudflare API email authentication
-	CLOUDFLARE_KEY                    = EnvString("CLOUDFLARE_KEY", "")                       // (optional) key used for Cloudflare API email authentication
-	CLOUDFLARE_TOKEN                  = EnvString("CLOUDFLARE_TOKEN", "")                     // (optional) token used for Cloudflare API token authentication
-	CLOUDFLARE_USER_SERVICE_KEY       = EnvString("CLOUDFLARE_USER_SERVICE_KEY", "")          // (optional) key used for Cloudflare API user service key authentication
-	CLOUDFLARE_ZONES                  = EnvString("CLOUDFLARE_ZONES", "")                     // (required) comma-separated list of zone names to scrape for metrics (e.g. "example.com,example.org")
-	CLOUDFLARE_SCRAPE_ANALYTICS_SINCE = EnvString("CLOUDFLARE_SCRAPE_ANALYTICS_SINCE", "24h") // (optional) `since` parameter of calls to the Cloudflare Analytics API ("Free" tenants have a minimum of 24h)
-	EXPORTER_LISTEN_ADDR              = EnvString("EXPORTER_LISTEN_ADDR", "127.0.0.1:9199")   // (optional) address for the exporter to bind to
+	CLOUDFLARE_KEY              = EnvString("CLOUDFLARE_KEY", "")              // (optional) key used for Cloudflare API email authentication
+	CLOUDFLARE_TOKEN            = EnvString("CLOUDFLARE_TOKEN", "")            // (optional) token used for Cloudflare API token authentication
+	CLOUDFLARE_USER_SERVICE_KEY = EnvString("CLOUDFLARE_USER_SERVICE_KEY", "") // (optional) key used for Cloudflare API user service key authentication
 
-	cloudflare_metrics *CloudflareMetrics
+	cloudflareEmail         = kingpin.Flag("cloudflare.email", "email used for Cloudflare API email authentication, env: CLOUDFLARE_EMAIL").Default(EnvString("CLOUDFLARE_EMAIL", "")).String()
+	cloudflareZones         = kingpin.Flag("cloudflare.zones", "(required) comma-separated list of zone names to scrape for metrics (e.g. 'example.com,example.org'), env: CLOUDFLARE_ZONES").Default(EnvString("CLOUDFLARE_ZONES", "")).String()
+	cloudflareAccounts      = kingpin.Flag("cloudflare.accounts", "comma-separated list of account ids to scrape for metrics (e.g. '123548648,123548644868'), env: CLOUDFLARE_ACCOUNTS").Default(EnvString("CLOUDFLARE_ACCOUNTS", "")).String()
+	cloudflareSince         = kingpin.Flag("cloudflare.since", "`since` parameter of calls to the Cloudflare Analytics API ('Free' tenants have a minimum of 24h), env: CLOUDFLARE_SCRAPE_ANALYTICS_SINCE").Default(EnvString("CLOUDFLARE_SCRAPE_ANALYTICS_SINCE", "24h")).String()
+	cloudflareIncludeAccess = kingpin.Flag("cloudflare.include-access", "bool to enable access-related metrics").Default("false").Bool()
+	exporterListenAddr      = kingpin.Flag("web.listen-addr", "address for the exporter to bind to, env: EXPORTER_LISTEN_ADDR").Default(EnvString("EXPORTER_LISTEN_ADDR", "127.0.0.1:9199")).String()
+	cloudflare_metrics      *CloudflareMetrics
 )
 
 func main() {
 	var err error
-	cloudflare_metrics, err = New(CLOUDFLARE_EMAIL, CLOUDFLARE_KEY, CLOUDFLARE_TOKEN, CLOUDFLARE_USER_SERVICE_KEY, CLOUDFLARE_ZONES, CLOUDFLARE_SCRAPE_ANALYTICS_SINCE)
+	kingpin.HelpFlag.Short('h')
+	kingpin.Parse()
+	config := ExporterConfig{
+		*cloudflareEmail,
+		CLOUDFLARE_KEY,
+		CLOUDFLARE_TOKEN,
+		CLOUDFLARE_USER_SERVICE_KEY,
+		*cloudflareZones,
+		*cloudflareAccounts,
+		*cloudflareSince,
+		*cloudflareIncludeAccess,
+	}
+	cloudflare_metrics, err = New(config)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("serving metrics at http://%v/metrics\n", EXPORTER_LISTEN_ADDR)
-	log.Fatal(ListenAndServe(EXPORTER_LISTEN_ADDR))
+	log.Printf("serving metrics at http://%v/metrics\n", *exporterListenAddr)
+	log.Fatal(ListenAndServe(*exporterListenAddr))
 }


### PR DESCRIPTION
While my initial plan to include metrics for access service token expirations scope-creeped a bit to include providing flags (I didn't like the idea of a toggle being an environment variable), I hope this PR isn't too offensive. 

On my initial pass-through I'm only adding a metric for the expiration time of access service tokens in the provided accounts. This is only shown when --cloudflare.include-access is passed in. Hope you don't mind! 

Cheers,
Michael